### PR TITLE
Remove duplicate g:roam_link_format in documentation.

### DIFF
--- a/doc/roam.txt
+++ b/doc/roam.txt
@@ -317,13 +317,6 @@ setting. >
 
 <
 
-                                                       *g:roam_link_format*
-Format used for generated links. You can change this variable if you are not
-satisfied with the default format.
->
-   let g:roam_link_format="[%title](%link)"
-<
-
                                                      *g:roam_random_chars*
 
 Number of characters used in `%random` roam name format.

--- a/doc/tags
+++ b/doc/tags
@@ -38,7 +38,6 @@ g:roam_default_mappings	roam.txt	/*g:roam_default_mappings*
 g:roam_front_matter	roam.txt	/*g:roam_front_matter*
 g:roam_fzf_command	roam.txt	/*g:roam_fzf_command*
 g:roam_link_format	roam.txt	/*g:roam_link_format*
-g:roam_link_format	roam.txt	/*g:roam_link_format*
 g:roam_new_title_format	roam.txt	/*g:roam_new_title_format*
 g:roam_random_chars	roam.txt	/*g:roam_random_chars*
 g:roam_template_path	roam.txt	/*g:roam_template_path*


### PR DESCRIPTION
This appears to be causing errors on startup with Lazy.nvim at least. I removed the second instance which doesn't add more information compared to the first.

I tested by replacing `jeffmm/vim-roam` in my config with my fork, and got no errors. I also forced remove/reinstalled to double-check.